### PR TITLE
fix error installing java caused by outdated apt

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,4 +18,5 @@
 # limitations under the License.
 #
 
+include_recipe "apt"
 include_recipe "java::#{node['java']['install_flavor']}"


### PR DESCRIPTION
Though apt is in the depend list, it is never actually included. In my case, java couldn't be installed because of an outdated apt.

How to reproduce:
- Install vagrant base box: http://vagrantup.com/
- put java cookbook in a projects /cookbooks/ dir and configure vagrant to use chef-solo
